### PR TITLE
feat: add login to signup intent

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="DesignSurface">
+    <option name="filePathToZoomLevelMap">
+      <map>
+        <entry key="..\:/Users/ssly1/dokkang-application/app/src/main/res/layout/activity_main.xml" value="0.1875" />
+        <entry key="..\:/Users/ssly1/dokkang-application/app/src/main/res/layout/activity_sign_up.xml" value="0.1875" />
+        <entry key="..\:/Users/ssly1/dokkang-application/app/src/main/res/layout/activity_sign_up2.xml" value="0.1875" />
+      </map>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="edu.skku.cs.dokkang">
+    package="edu.skku.cs.dokkang" >
 
     <application
         android:allowBackup="true"
@@ -8,10 +8,13 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Dokkang">
+        android:theme="@style/Theme.Dokkang" >
+        <activity
+            android:name=".Sign_Up"
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/edu/skku/cs/dokkang/MainActivity.java
+++ b/app/src/main/java/edu/skku/cs/dokkang/MainActivity.java
@@ -2,6 +2,7 @@ package edu.skku.cs.dokkang;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.EditText;
@@ -28,7 +29,8 @@ public class MainActivity extends AppCompatActivity {
         Button signupButton = findViewById(R.id.signupButton);
         /* signup - onClick */
         signupButton.setOnClickListener(view -> {
-
+            Intent intent = new Intent(MainActivity.this, Sign_Up.class);
+            startActivity(intent);
         });
     }
 }

--- a/app/src/main/java/edu/skku/cs/dokkang/Sign_Up.java
+++ b/app/src/main/java/edu/skku/cs/dokkang/Sign_Up.java
@@ -1,0 +1,45 @@
+package edu.skku.cs.dokkang;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+public class Sign_Up extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sign_up);
+
+        // sign-up information
+        EditText signup_id = findViewById(R.id.signup_idEditText);
+        EditText signup_pw = findViewById(R.id.signup_pwEditText);
+        EditText signup_nickname = findViewById(R.id.nnEditText);
+        EditText signup_department = findViewById(R.id.dpEditText);
+
+        // sign-up button
+        Button signup_btn = findViewById(R.id.loginButton);
+
+        signup_btn.setOnClickListener(view -> {
+            /* 서버와 통신하는 부분 */
+
+            boolean result = true;
+            /* 서버와 통신하는 부분 */
+
+            if(result) {
+                finish();
+            }
+            else{
+                Toast.makeText(getApplicationContext(), "Failed",Toast.LENGTH_SHORT).show();
+            }
+
+        });
+
+    }
+
+
+
+
+}


### PR DESCRIPTION
1. sign up 버튼을 누르면 login activity에서 sign-up activity로 가는 기능 추가

일단 sign-up activity에서 버튼 누르면 바로 sign-up activity가 finish하게 해놨습니다. 